### PR TITLE
docs(GraalVM/CE): fix broken link

### DIFF
--- a/GraalVM/CE/README.md
+++ b/GraalVM/CE/README.md
@@ -1,3 +1,3 @@
 # Update:
 
-The GraalVM CE dockerfiles moved to: https://github.com/graalvm/container/tree/master/community
+The GraalVM CE dockerfiles moved to: https://github.com/graalvm/container/tree/master/graalvm-community


### PR DESCRIPTION
- Update broken link caused by name change in `graalvm-community` PR [[GS-4824] Updating dockerfiles and readme file ](https://github.com/graalvm/container/pull/76)